### PR TITLE
71 create a channel function to remove users from user and operator lists upon logout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ SRCS=		Server.cpp \
 				commands/PartCommand.cpp \
 				commands/NamesCommand.cpp \
 				commands/InviteCommand.cpp \
+				commands/LogoutCommand.cpp \
 				commands/ModeCommand.cpp
 SRCS_NAME=	$(addprefix $(SRCS_PATH), $(SRC_NAME) $(SRCS))
 ### OBJECT FILES ###

--- a/incl/Channel.hpp
+++ b/incl/Channel.hpp
@@ -2,6 +2,7 @@
 #ifndef __CHANNEL_HPP__
 #define __CHANNEL_HPP__
 
+#include <algorithm>
 #include <iostream>
 #include <map>
 #include <vector>
@@ -34,6 +35,8 @@ class Channel {
   std::string      getName( void );
   std::string      getPassword( void );
   unsigned int     getMaxUsers( void );
+  void             removeUser( int _userFD );
+  void             removeOperator( int _userFD );
 
   void setOperator( int user );  // it will be more like void addOperator( User *user );
   void setInviteOnly( bool inviteOnly );

--- a/incl/CommandFactory.hpp
+++ b/incl/CommandFactory.hpp
@@ -11,6 +11,7 @@
 #include "commands/InviteCommand.hpp"
 #include "commands/JoinCommand.hpp"
 #include "commands/KickCommand.hpp"
+#include "commands/LogoutCommand.hpp"
 #include "commands/ModeCommand.hpp"
 #include "commands/NamesCommand.hpp"
 #include "commands/NickCommand.hpp"

--- a/incl/CommandFactory.hpp
+++ b/incl/CommandFactory.hpp
@@ -25,12 +25,16 @@ typedef ACommand *( *funcPtr )( Authenticator *authenticator, ChannelManager *ch
 
 class CommandFactory {
  private:
- public:
+  Authenticator  *_authenticator;
+  ChannelManager *_channelManager;
   CommandFactory();
+
+ public:
+  CommandFactory( const char *password );
   ~CommandFactory();
   CommandFactory( CommandFactory const &src );
   CommandFactory &operator=( CommandFactory const &src );
-  ACommand       *makeCommand( Authenticator *authenticator, ChannelManager *channelmanager, int fd, std::string commandName, std::string args );
+  ACommand       *makeCommand( int fd, std::string commandName, std::string args );
 };
 
 #endif

--- a/incl/Server.hpp
+++ b/incl/Server.hpp
@@ -41,11 +41,9 @@ class Server {
   int                 _fdSize;
   std::vector<pollfd> _pfds;
 
-  Parser          _parser;
-  Authenticator  *_authenticator;
-  ChannelManager *_channelManager;
-  CommandFactory  _commandFactory;
-  Messenger       _messenger;
+  Parser         _parser;
+  CommandFactory _commandFactory;
+  Messenger      _messenger;
 
   void addToPfds( int fd );
   int  delFromPfds( int fd );

--- a/incl/commands/LogoutCommand.hpp
+++ b/incl/commands/LogoutCommand.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#ifndef __LOGOUTCOMMAND_HPP__
+#define __LOGOUTCOMMAND_HPP__
+
+#include <iostream>
+
+#include "ACommand.hpp"
+
+class LogoutCommand : public ACommand {
+ private:
+ public:
+  LogoutCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd );
+  ~LogoutCommand();
+  LogoutCommand( LogoutCommand const &src );
+  LogoutCommand   &operator=( LogoutCommand const &src );
+  PreparedResponse execute() const;
+};
+
+#endif

--- a/srcs/Authenticator.cpp
+++ b/srcs/Authenticator.cpp
@@ -42,7 +42,7 @@ bool Authenticator::nickNameExists( int fd, std::string nickName ) {
   }
   return false;
 }
-int Authenticator::getFdFromNick( std::string str ){
+int Authenticator::getFdFromNick( std::string str ) {
   for ( std::map<int, User*>::iterator it = _users.begin(); it != _users.end(); it++ ) {
     if ( it->second && it->second->getNick() == str )
       return it->first;
@@ -87,9 +87,9 @@ bool Authenticator::authenticateUser( int fd ) {
 
 void Authenticator::setUserIp( int fd ) {
   struct sockaddr_in addr;
-  socklen_t          userlen = sizeof(addr);
-  if (getpeername( fd , (struct sockaddr *)&addr, &userlen ) != -1 )
-    _users[fd]->setIp(ntohl(addr.sin_addr.s_addr));
+  socklen_t          userlen = sizeof( addr );
+  if ( getpeername( fd, (struct sockaddr*)&addr, &userlen ) != -1 )
+    _users[fd]->setIp( ntohl( addr.sin_addr.s_addr ) );
 }
 
 void Authenticator::releaseUserInfo( int fd ) {

--- a/srcs/Channel.cpp
+++ b/srcs/Channel.cpp
@@ -64,6 +64,18 @@ unsigned int Channel::getMaxUsers( void ) {
   return _maxUsers;
 }
 
+void Channel::removeUser( int _userFD ) {
+  std::vector<int>::iterator it = std::find( _users.begin(), _users.end(), _userFD );
+  if ( it != _users.end() )
+    _users.erase( it );
+}
+
+void Channel::removeOperator( int _userFD ) {
+  std::vector<int>::iterator it = std::find( _operators.begin(), _operators.end(), _userFD );
+  if ( it != _operators.end() )
+    _operators.erase( it );
+}
+
 void Channel::setOperator( int user ) {
   _operators.push_back( user );
 }

--- a/srcs/CommandFactory.cpp
+++ b/srcs/CommandFactory.cpp
@@ -55,9 +55,13 @@ ACommand *makeModeCommand( Authenticator *authenticator, ChannelManager *channel
   return new ModeCommand( authenticator, channelmanager, args, fd );
 }
 
+ACommand *makeLogoutCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
+  return new LogoutCommand( authenticator, channelmanager, args, fd );
+}
+
 ACommand *CommandFactory::makeCommand( Authenticator  *authenticator,
                                        ChannelManager *channelmanager, int fd, std::string commandName, std::string args ) {
-  const std::string enumCommand[] = { "USER", "PASS", "NICK", "PRIVMSG", "JOIN", "KICK", "INVITE", "PART", "NAMES", "MODE" };
+  const std::string enumCommand[] = { "USER", "PASS", "NICK", "PRIVMSG", "JOIN", "KICK", "INVITE", "PART", "NAMES", "MODE", "LOGOUT" };
   const funcPtr     enumFunc[]    = {
       &makeUserCommand,
       &makePassCommand,
@@ -69,8 +73,9 @@ ACommand *CommandFactory::makeCommand( Authenticator  *authenticator,
       &makePartCommand,
       &makeNamesCommand,
       &makeModeCommand,
+      &makeLogoutCommand,
   };
-  for ( int i = 0; i < 10; i++ ) {
+  for ( int i = 0; i < (int)( sizeof( enumCommand ) / sizeof( std::string ) ); i++ ) {
     if ( commandName == enumCommand[i] ) {
       ACommand *c = ( enumFunc[i]( authenticator, channelmanager, args, fd ) );
       return c;

--- a/srcs/CommandFactory.cpp
+++ b/srcs/CommandFactory.cpp
@@ -1,8 +1,16 @@
 #include "CommandFactory.hpp"
 
-CommandFactory::CommandFactory() {}
+CommandFactory::CommandFactory() {
+}
+
+CommandFactory::CommandFactory( const char *password ) {
+  _authenticator  = new Authenticator( password );
+  _channelManager = new ChannelManager();
+}
 
 CommandFactory::~CommandFactory() {
+  delete _authenticator;
+  delete _channelManager;
 }
 
 CommandFactory::CommandFactory( CommandFactory const &src ) {
@@ -15,52 +23,51 @@ CommandFactory &CommandFactory::operator=( CommandFactory const &src ) {
   return ( *this );
 }
 
-ACommand *makeUserCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new UserCommand( authenticator, channelmanager, args, fd );
+ACommand *makeUserCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new UserCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makePassCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new PassCommand( authenticator, channelmanager, args, fd );
+ACommand *makePassCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new PassCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makeNickCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new NickCommand( authenticator, channelmanager, args, fd );
+ACommand *makeNickCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new NickCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makePrivCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new PrivCommand( authenticator, channelmanager, args, fd );
+ACommand *makePrivCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new PrivCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makeJoinCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new JoinCommand( authenticator, channelmanager, args, fd );
+ACommand *makeJoinCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new JoinCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makeKickCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new KickCommand( authenticator, channelmanager, args, fd );
+ACommand *makeKickCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new KickCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makeInviteCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new InviteCommand( authenticator, channelmanager, args, fd );
+ACommand *makeInviteCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new InviteCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makePartCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new PartCommand( authenticator, channelmanager, args, fd );
+ACommand *makePartCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new PartCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makeNamesCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new NamesCommand( authenticator, channelmanager, args, fd );
+ACommand *makeNamesCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new NamesCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makeModeCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new ModeCommand( authenticator, channelmanager, args, fd );
+ACommand *makeModeCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new ModeCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *makeLogoutCommand( Authenticator *authenticator, ChannelManager *channelmanager, std::string args, int fd ) {
-  return new LogoutCommand( authenticator, channelmanager, args, fd );
+ACommand *makeLogoutCommand( Authenticator *authenticator, ChannelManager *channelManager, std::string args, int fd ) {
+  return new LogoutCommand( authenticator, channelManager, args, fd );
 }
 
-ACommand *CommandFactory::makeCommand( Authenticator  *authenticator,
-                                       ChannelManager *channelmanager, int fd, std::string commandName, std::string args ) {
+ACommand *CommandFactory::makeCommand( int fd, std::string commandName, std::string args ) {
   const std::string enumCommand[] = { "USER", "PASS", "NICK", "PRIVMSG", "JOIN", "KICK", "INVITE", "PART", "NAMES", "MODE", "LOGOUT" };
   const funcPtr     enumFunc[]    = {
       &makeUserCommand,
@@ -77,9 +84,9 @@ ACommand *CommandFactory::makeCommand( Authenticator  *authenticator,
   };
   for ( int i = 0; i < (int)( sizeof( enumCommand ) / sizeof( std::string ) ); i++ ) {
     if ( commandName == enumCommand[i] ) {
-      ACommand *c = ( enumFunc[i]( authenticator, channelmanager, args, fd ) );
+      ACommand *c = ( enumFunc[i]( _authenticator, _channelManager, args, fd ) );
       return c;
     }
   }
-  return new NoCommand( authenticator, channelmanager, args, fd );
+  return new NoCommand( _authenticator, _channelManager, args, fd );
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -172,6 +172,7 @@ std::string Server::receiveMessage( int i, int senderFD ) throw( std::exception 
     std::cout << "connection closed from " << senderFD << std::endl;
     close( senderFD );
     i -= delFromPfds( senderFD );
+    return ( "LOGOUT" );
   }
   buf[nbytes] = '\0';
   message     = buf;
@@ -205,7 +206,7 @@ int Server::delFromPfds( int fd ) {
   std::vector<pollfd>::iterator it = _pfds.begin();
   while ( it != _pfds.end() ) {
     if ( it->fd == fd ) {
-      _authenticator->releaseUserInfo( fd );
+      // _authenticator->releaseUserInfo( fd );
       _pfds.erase( it );
       return ( 1 );
     }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -4,19 +4,14 @@
 
 bool Server::_stopServer = false;
 
-Server::Server() {
-  _authenticator  = new Authenticator( "invalid" );
-  _channelManager = new ChannelManager();
+Server::Server() : _commandFactory( "invalid" ) {
 }
 
 Server::~Server() {
   clearUsers();
-  delete _authenticator;
-  delete _channelManager;
 }
 
-Server::Server( Server const &src ) : _authenticator( src._authenticator ),
-                                      _channelManager( src._channelManager ) {
+Server::Server( Server const &src ) : _commandFactory( src._commandFactory ) {
   *this = src;
 }
 
@@ -33,15 +28,13 @@ Server &Server::operator=( Server const &src ) {
   return ( *this );
 }
 
-Server::Server( char const *port, char const *password ) throw( std::exception ) {
+Server::Server( char const *port, char const *password ) throw( std::exception ) : _commandFactory( password ) {
   setPort( port );
   setPassword( password );
   setupListeningSocket();
-  _parser         = Parser();
-  _authenticator  = new Authenticator( _password.c_str() );
-  _channelManager = new ChannelManager();
-  _messenger      = Messenger( _listeningSocket );
-  _fdSize         = 5;
+  _parser    = Parser();
+  _messenger = Messenger( _listeningSocket );
+  _fdSize    = 5;
 }
 
 void Server::setPassword( char const *password ) throw( std::exception ) {
@@ -153,7 +146,7 @@ void Server::processMessage( int i ) {
   str        = receiveMessage( i, senderFD );
   parsedMsgs = _parser.parseMsg( str );
   for ( std::vector<ParsedMsg>::iterator it = parsedMsgs.begin(); it != parsedMsgs.end(); it++ ) {
-    command = _commandFactory.makeCommand( _authenticator, _channelManager, senderFD, it->commandName, it->args );
+    command = _commandFactory.makeCommand( senderFD, it->commandName, it->args );
     pr      = command->execute();
     delete command;
     _messenger.respond( pr );
@@ -206,7 +199,6 @@ int Server::delFromPfds( int fd ) {
   std::vector<pollfd>::iterator it = _pfds.begin();
   while ( it != _pfds.end() ) {
     if ( it->fd == fd ) {
-      // _authenticator->releaseUserInfo( fd );
       _pfds.erase( it );
       return ( 1 );
     }

--- a/srcs/commands/LogoutCommand.cpp
+++ b/srcs/commands/LogoutCommand.cpp
@@ -1,0 +1,28 @@
+#include "commands/LogoutCommand.hpp"
+
+LogoutCommand::LogoutCommand( Authenticator *authenticator, ChannelManager *channelManager,
+                              std::string args, int fd ) : ACommand( "LOGOUT", authenticator, channelManager, args, fd ) {}
+
+LogoutCommand::~LogoutCommand() {
+}
+
+LogoutCommand::LogoutCommand( LogoutCommand const &src ) : ACommand( src._authenticator, src._channelManager ) {
+  *this = src;
+}
+
+LogoutCommand &LogoutCommand::operator=( LogoutCommand const &src ) {
+  if ( this == &src )
+    return ( *this );
+  ACommand::operator=( src );
+  return ( *this );
+}
+
+PreparedResponse LogoutCommand::execute() const {
+  std::map<std::string, Channel *> channels = _channelManager->getAllChannels();
+  for ( std::map<std::string, Channel *>::iterator it = channels.begin(); it != channels.end(); it++ ) {
+    it->second->removeUser( _userFD );
+    it->second->removeOperator( _userFD );
+  }
+  _authenticator->releaseUserInfo( _userFD );
+  return PreparedResponse();
+}


### PR DESCRIPTION
Added LOGOUT command. 
This command will remove the user from authenticator and all channels.

Since the Server will not need the Autenticator to remove the user info. The command factory will now have the Authenticator and Channel Manager to pass to each command.